### PR TITLE
Update README.md to document packer_cache correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ In the automated approach we can pass all of the required information to the cro
 to completely build our Operating System image with no user involvement.
 
 ```
-docker run -it -v $PWD/cache:/packer/packer_cache \
+docker run -it -v $PWD/packer_cache:/packer/packer_cache \
 -e NAME=tink \
 -e WINDOWS_VERSION=2016 \
 -e ISO_URL=https://software-download.microsoft.com/download/pr/Windows_Server_2016_Datacenter_EVAL_en-us_14393_refresh.ISO \


### PR DESCRIPTION
Signed-off-by: Nahum Shalman <nshalman@equinix.com>

## Description

When I followed the README.md with copy-and paste I ended up with an unexpected `cache` directory.
This fixes the documentation to match what `.gitignore` and `.dockerignore` expect