### PR TITLE
fixes to builder environment vars

### DIFF
--- a/configs/windows-fast.json
+++ b/configs/windows-fast.json
@@ -1,8 +1,8 @@
 {
-  "_comment1": "NAME=windows-10-enterprise-x64-eval           WINDOWS_VERSION=10   VIRTIO_WIN_ISO_DIR=./packer_cache/virtio-win ISO_URL=https://software-download.microsoft.com/download/pr/19041.264.200511-0456.vb_release_svc_refresh_CLIENTENTERPRISEEVAL_OEMRET_x64FRE_en-us.iso                                             PACKER_IMAGES_OUTPUT_DIR=/var/tmp/ TMPDIR=/var/tmp/ packer build -only=qemu windows.json",
-  "_comment2": "NAME=windows-server-2012_r2-standard-x64-eval WINDOWS_VERSION=2012 VIRTIO_WIN_ISO_DIR=./packer_cache/virtio-win ISO_URL=https://care.dlservice.microsoft.com/dl/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO PACKER_IMAGES_OUTPUT_DIR=/var/tmp/ TMPDIR=/var/tmp/ packer build -only=qemu windows.json",
-  "_comment3": "NAME=windows-server-2016-standard-x64-eval    WINDOWS_VERSION=2016 VIRTIO_WIN_ISO_DIR=./packer_cache/virtio-win ISO_URL=https://software-download.microsoft.com/download/pr/Windows_Server_2016_Datacenter_EVAL_en-us_14393_refresh.ISO                                                                           PACKER_IMAGES_OUTPUT_DIR=/var/tmp/ TMPDIR=/var/tmp/ packer build -only=qemu windows.json",
-  "_comment4": "NAME=windows-server-2019-standard-x64-eval    WINDOWS_VERSION=2019 VIRTIO_WIN_ISO_DIR=./packer_cache/virtio-win ISO_URL=https://software-download.microsoft.com/download/pr/17763.737.190906-2324.rs5_release_svc_refresh_SERVER_EVAL_x64FRE_en-us_1.iso                                                          PACKER_IMAGES_OUTPUT_DIR=/var/tmp/ TMPDIR=/var/tmp/ packer build -only=qemu windows.json",
+  "_comment1": "NAME=windows-10-enterprise-x64-eval           VERSION=10   VIRTIO_WIN_ISO_DIR=./packer_cache/virtio-win ISO_URL=https://software-download.microsoft.com/download/pr/19041.264.200511-0456.vb_release_svc_refresh_CLIENTENTERPRISEEVAL_OEMRET_x64FRE_en-us.iso                                             PACKER_IMAGES_OUTPUT_DIR=/var/tmp/ TMPDIR=/var/tmp/ packer build -only=qemu windows.json",
+  "_comment2": "NAME=windows-server-2012_r2-standard-x64-eval VERSION=2012 VIRTIO_WIN_ISO_DIR=./packer_cache/virtio-win ISO_URL=https://care.dlservice.microsoft.com/dl/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO PACKER_IMAGES_OUTPUT_DIR=/var/tmp/ TMPDIR=/var/tmp/ packer build -only=qemu windows.json",
+  "_comment3": "NAME=windows-server-2016-standard-x64-eval    VERSION=2016 VIRTIO_WIN_ISO_DIR=./packer_cache/virtio-win ISO_URL=https://software-download.microsoft.com/download/pr/Windows_Server_2016_Datacenter_EVAL_en-us_14393_refresh.ISO                                                                           PACKER_IMAGES_OUTPUT_DIR=/var/tmp/ TMPDIR=/var/tmp/ packer build -only=qemu windows.json",
+  "_comment4": "NAME=windows-server-2019-standard-x64-eval    VERSION=2019 VIRTIO_WIN_ISO_DIR=./packer_cache/virtio-win ISO_URL=https://software-download.microsoft.com/download/pr/17763.737.190906-2324.rs5_release_svc_refresh_SERVER_EVAL_x64FRE_en-us_1.iso                                                          PACKER_IMAGES_OUTPUT_DIR=/var/tmp/ TMPDIR=/var/tmp/ packer build -only=qemu windows.json",
   "builders": [
     {
       "accelerator": "{{ user `accelerator` }}",
@@ -95,7 +95,7 @@
   ],
   "variables": {
     "accelerator": "kvm",
-    "autounattend": "http/{{ env `WINDOWS_VERSION` }}/Autounattend.xml",
+    "autounattend": "http/{{ env `VERSION` }}/Autounattend.xml",
     "cpus": "2",
     "disk_size": "21000",
     "headless": "true",
@@ -105,7 +105,7 @@
     "name": "{{ env `NAME` }}",
     "packer_images_output_dir": "{{ env `PACKER_IMAGES_OUTPUT_DIR` }}",
     "virtio_win_iso_dir": "{{ env `VIRTIO_WIN_ISO_DIR` }}",
-    "windows_version": "{{ env `WINDOWS_VERSION` }}",
+    "windows_version": "{{ env `VERSION` }}",
     "winrm_password": "tinkerbell",
     "winrm_username": "tinkerbell"
   }


### PR DESCRIPTION
## Description

Fixes the environment variable from WINDOWS_VERSION to VERSION (keeps things inline)

## Why is this needed

fast builds are broken.

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
