### PR TITLE
fixes creds on autounattended

### DIFF
--- a/crocodile.sh
+++ b/crocodile.sh
@@ -21,6 +21,8 @@ ALMAISO="https://repo.almalinux.org/almalinux/8.3-rc/isos/x86_64/AlmaLinux-8.3-r
 # UBUNTU URLS
 FOCALISO="http://cloud-images.ubuntu.com/releases/focal/release/ubuntu-20.04-server-cloudimg-amd64.img"
 
+export VIRTIO_WIN_ISO_DIR="/var/tmp/virtio-win"
+
 CONFIG=./configs/windows.json
 tput setaf 2
 if [[ $1 == "fast" ]] ; then

--- a/http/windows-2012/Autounattend.xml
+++ b/http/windows-2012/Autounattend.xml
@@ -79,8 +79,8 @@
                     <WillShowUI>OnError</WillShowUI>
                 </ProductKey>
                 <AcceptEula>true</AcceptEula>
-                <FullName>Vagrant</FullName>
-                <Organization>Vagrant</Organization>
+                <FullName>tinkerbell</FullName>
+                <Organization>Equinix Metal</Organization>
             </UserData>
         </component>
     </settings>
@@ -139,11 +139,11 @@
         <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" language="neutral" name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" versionScope="nonSxS">
             <AutoLogon>
                 <Password>
-                    <Value>vagrant</Value>
+                    <Value>tinkerbell</Value>
                     <PlainText>true</PlainText>
                 </Password>
                 <Enabled>true</Enabled>
-                <Username>vagrant</Username>
+                <Username>tinkerbell</Username>
             </AutoLogon>
             <FirstLogonCommands>
                 <SynchronousCommand wcm:action="add">
@@ -182,19 +182,19 @@
             </OOBE>
             <UserAccounts>
                 <AdministratorPassword>
-                    <Value>vagrant</Value>
+                    <Value>tinkerbell</Value>
                     <PlainText>true</PlainText>
                 </AdministratorPassword>
                 <LocalAccounts>
                     <LocalAccount wcm:action="add">
                         <Password>
-                            <Value>vagrant</Value>
+                            <Value>tinkerbell</Value>
                             <PlainText>true</PlainText>
                         </Password>
                         <Group>administrators</Group>
-                        <DisplayName>Vagrant</DisplayName>
-                        <Name>vagrant</Name>
-                        <Description>Vagrant User</Description>
+                        <DisplayName>tinkerbell</DisplayName>
+                        <Name>tinkerbell</Name>
+                        <Description>tinkerbell User</Description>
                     </LocalAccount>
                 </LocalAccounts>
             </UserAccounts>

--- a/http/windows-2016/Autounattend.xml
+++ b/http/windows-2016/Autounattend.xml
@@ -192,9 +192,9 @@
                             <PlainText>true</PlainText>
                         </Password>
                         <Group>administrators</Group>
-                        <DisplayName>Tinkerbell</DisplayName>
+                        <DisplayName>tinkerbell</DisplayName>
                         <Name>tinkerbell</Name>
-                        <Description>Tinkerbell User</Description>
+                        <Description>tinkerbell User</Description>
                     </LocalAccount>
                 </LocalAccounts>
             </UserAccounts>

--- a/http/windows-2019/Autounattend.xml
+++ b/http/windows-2019/Autounattend.xml
@@ -79,8 +79,8 @@
                     <WillShowUI>OnError</WillShowUI>
                 </ProductKey>
                 <AcceptEula>true</AcceptEula>
-                <FullName>Vagrant</FullName>
-                <Organization>Vagrant</Organization>
+                <FullName>tinkerbell</FullName>
+                <Organization>Equinix Metal</Organization>
             </UserData>
         </component>
     </settings>
@@ -139,11 +139,11 @@
         <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" language="neutral" name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" versionScope="nonSxS">
             <AutoLogon>
                 <Password>
-                    <Value>vagrant</Value>
+                    <Value>tinkerbell</Value>
                     <PlainText>true</PlainText>
                 </Password>
                 <Enabled>true</Enabled>
-                <Username>vagrant</Username>
+                <Username>tinkerbell</Username>
             </AutoLogon>
             <FirstLogonCommands>
                 <SynchronousCommand wcm:action="add">
@@ -182,19 +182,19 @@
             </OOBE>
             <UserAccounts>
                 <AdministratorPassword>
-                    <Value>vagrant</Value>
+                    <Value>tinkerbell</Value>
                     <PlainText>true</PlainText>
                 </AdministratorPassword>
                 <LocalAccounts>
                     <LocalAccount wcm:action="add">
                         <Password>
-                            <Value>vagrant</Value>
+                            <Value>tinkerbell</Value>
                             <PlainText>true</PlainText>
                         </Password>
                         <Group>administrators</Group>
-                        <DisplayName>Vagrant</DisplayName>
-                        <Name>vagrant</Name>
-                        <Description>Vagrant User</Description>
+                        <DisplayName>tinkerbell</DisplayName>
+                        <Name>tinkerbell</Name>
+                        <Description>tinkerbell User</Description>
                     </LocalAccount>
                 </LocalAccounts>
             </UserAccounts>


### PR DESCRIPTION
## Description

Fixes the credentials on the `Autounattended.xml` files.

## Why is this needed

The wrong creds break winrm

Fixes: #17 

## How Has This Been Tested?

ran locally

```
-rw-r--r--  1 root root 4964742910 Apr  6 11:27 tink-windows-2012.raw.gz
-rw-r--r--  1 root root 5037848508 Apr  6 08:28 tink-windows-2016.raw.bzip2
-rw-r--r--  1 root root 5076119865 Apr  6 08:54 tink-windows-2016.raw.gz
-rw-r--r--  1 root root 4881842907 Apr  6 11:17 tink-windows-2019.raw.gz
```


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
