### PR TITLE
Documentation update for building ESXi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+run: image
+	docker run -it --rm \
+	-v $(PWD)/packer_cache:/packer/packer_cache \
+	-v $(PWD)/images:/var/tmp/images \
+	--net=host \
+	--device=/dev/kvm \
+	--device=/dev/net/tun \
+	--cap-add=NET_ADMIN \
+	croc:latest
+
+.PHONY: image
+image:
+	docker build -t croc .

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Crocodile
 
-The **Crocodile** repository contains everything that a user should need in order to build Windows{x} compressed raw images
-for [tinkerbell](https://tinkerbell.org). The repository contains a number of key peices:
+The **Crocodile** repository contains everything that a user should need in order to build compressed raw images
+of Windows{x}, VMware ESXi, and various Linux distros
+for [tinkerbell](https://tinkerbell.org). The repository contains a number of key pieces:
 
 ## Dockerfile
 
@@ -11,6 +12,16 @@ the Operating System images:
 - Packer
 - Qemu-kvm
 - virtio drivers (needed for Qemu to work with disks)
+
+## Host requirements
+
+### Minimal
+For most OS image builds, all you should really need is Docker on a reasonably modern Linux distro with KVM virtualization support.
+
+### ESXi special requirements
+To build ESXi images we depend on special bridged networking provided by libvirt-daemon.
+To confirm expected bridged networking, `ip link show virbr0` should succeed.
+You will also need to add `--device=/dev/net/tun --cap-add=NET_ADMIN" to your docker commands.
 
 ### Building our container image
 
@@ -45,49 +56,32 @@ croc:latest
 This will drop you into the crocodile shell for building your OS:
 
 ```
-                        .--.  .--.
-                       /    \/    \
-                      | .-.  .-.   \
-                      |/_  |/_  |   \
-                      || `\|| `\|    `----.
-                      |\0_/ \0_/    --,    \_
-    .--"""""-.       /              (` \     `-.
-   /          \-----'-.              \          \
-   \  () ()                         /`\          \
-   |                         .___.-'   |          \
-   \                        /` \|      /           ;
-    `-.___             ___.' .-.`.---.|             \
-       \| ``-..___,.-'`\| / /   /     |              `\
-        `      \|      ,`/ /   /   ,  /
-                `      |\ /   /    |\/
-                 ,   .'`-;   '     \/
-            ,    |\-'  .'   ,   .-'`
-          .-|\--;`` .-'     |\.'
-         ( `"'-.|\ (___,.--'`'
-          `-.    `"`          _.--'
-             `.          _.-'`-.
-               `''---''``       `."
-Select "quit"  when you've finished building Operating Systems
-1) windows-2012
-2) windows-2016
-3) windows-2019
-4) windows-10
-5) quit
-```
-
-### Automated
-
-In the automated approach we can pass all of the required information to the croc container
-to completely build our Operating System image with no user involvement.
-
-```
-docker run -it -v $PWD/packer_cache:/packer/packer_cache \
--e NAME=tink \
--e WINDOWS_VERSION=2016 \
--e ISO_URL=https://software-download.microsoft.com/download/pr/Windows_Server_2016_Datacenter_EVAL_en-us_14393_refresh.ISO \
--v $PWD/images:/var/tmp/images \
---net=host --device=/dev/kvm \
-croc:latest packer build -only="qemu" windows.json
+                          .--.  .--.
+                         /    \/    \
+                        | .-.  .-.   \
+                        |/_  |/_  |   \
+                        || `\|| `\|    `----.
+                        |\0_/ \0_/    --,    \_
+      .--"""""-.       /              (` \     `-.
+     /          \-----'-.              \          \
+     \  () ()                         /`\          \
+     |                         .___.-'   |          \
+     \                        /` \|      /           ;
+      `-.___             ___.' .-.`.---.|             \
+         \| ``-..___,.-'`\| / /   /     |              `\
+          `      \|      ,`/ /   /   ,  /
+                  `      |\ /   /    |\/
+                   ,   .'`-;   '     \/
+              ,    |\-'  .'   ,   .-'`
+            .-|\--;`` .-'     |\.'
+           ( `"'-.|\ (___,.--'`'
+            `-.    `"`          _.--'
+               `.          _.-'`-.
+                 `''---''``       `."
+Select quit (1)  when you've finished building Operating Systems
+1) quit		   4) esxi6.5	     7) ubuntu-2004   10) windows-2016
+2) alma		   5) esxi6.7	     8) windows-10    11) windows-2019
+3) arch		   6) esxi7.0	     9) windows-2012
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
## Description

Update the README.md to better reflect reality and to document ESXi's special requirements.

## Why is this needed

Current instructions in README.md don't quite work for ESXi.
Fixes: #22 

## How Has This Been Tested?

Documented in #22 

## How are existing users impacted? What migration steps/scripts do we need?

EXSi builds only work on machines with libvirt-daemon installed and only if the right flags are passed to Docker.

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
