### PR TITLE
fix the esxi 7.0 install

### DIFF
--- a/configs/esxi.json
+++ b/configs/esxi.json
@@ -19,7 +19,8 @@
       ],
       "memory": "{{ user `memory` }}",
       "output_directory": "{{ user `name` }}-qemu",
-      "net_device": "e1000",
+      "net_bridge": "virbr0",
+      "net_device": "vmxnet3",
       "qemuargs": [
           [ "-cpu", "host" ],
           [ "-smp", "2,sockets=2,cores=1,threads=1" ],


### PR DESCRIPTION
because esxi 7.0 no longer bundles the e1000 network interface driver

this also works with the esxi 6.5 and later versions

this requires packer 1.6.0+ as described in https://github.com/hashicorp/packer/issues/9156

without this fix, this is how the esxi boot fails:

![tink-esxi7 0-wrong-network-interface](https://user-images.githubusercontent.com/43356/119255765-57b6bb00-bbb5-11eb-80e4-e7b2d53b64bc.png)
