### PR TITLE
Add 'make lint' rule, address Docker and shell lint issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,32 @@
-FROM ubuntu:latest
-RUN apt-get update; apt-get upgrade -y; DEBIAN_FRONTEND=noninteractive apt-get install -y ansible git qemu-kvm unzip xorriso curl jq
+FROM ubuntu:hirsute-20210723
+
+# Disable DL3008 as it is not possible to pin virtual packages such as qemu-kvm
+# hadolint ignore=DL3008
+RUN apt-get update \
+ && DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
+   ansible=2.10.7-1 \
+   git=1:2.30.2-1ubuntu1 \
+   qemu-kvm \
+   unzip=6.0-26ubuntu1 \
+   xorriso=1.5.2-1 \
+   curl=7.74.0-1ubuntu2.1 \
+   jq=1.6-2.1ubuntu1 \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
 
 # Get virtio drivers (ensures a drive is usable for qemu
-RUN curl -L -o /var/tmp/virtio-win.iso https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/latest-virtio/virtio-win.iso; xorriso -report_about WARNING -osirrox on -indev /var/tmp/virtio-win.iso -extract / /var/tmp/virtio-win
+RUN curl -L -o /var/tmp/virtio-win.iso https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/latest-virtio/virtio-win.iso \
+  && xorriso -report_about WARNING -osirrox on -indev /var/tmp/virtio-win.iso -extract / /var/tmp/virtio-win \
+  && rm /var/tmp/virtio-win.iso
+
 ENV VIRTIO_WIN_ISO_DIR="/var/tmp/virtio-win"
 
 # Get LATEST release of packer 
-RUN export PACKER_LATEST_VERSION="$(curl -s https://checkpoint-api.hashicorp.com/v1/check/packer | jq -r -M '.current_version')"; curl -L -o /tmp/packer_linux_amd64.zip "https://releases.hashicorp.com/packer/${PACKER_LATEST_VERSION}/packer_${PACKER_LATEST_VERSION}_linux_amd64.zip" ; unzip /tmp/packer_linux_amd64.zip -d /usr/local/bin/ ; rm /tmp/packer_linux_amd64.zip
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN PLV="$(curl -s https://checkpoint-api.hashicorp.com/v1/check/packer | jq -r -M '.current_version')" \
+  && curl -L -o /tmp/packer_linux_amd64.zip "https://releases.hashicorp.com/packer/${PLV}/packer_${PLV}_linux_amd64.zip" \
+  && unzip /tmp/packer_linux_amd64.zip -d /usr/local/bin/ \
+  && rm /tmp/packer_linux_amd64.zip
 
 # Install the tinkerbell packer builds
 COPY . /packer/

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ run: image
 image:
 	docker build -t croc .
 
-# BEGIN: lint-install ../crocodile/
+# BEGIN: lint-install .
 # http://github.com/tinkerbell/lint-install
 
 
@@ -21,7 +21,7 @@ SHELLCHECK_VERSION ?= v0.7.2
 LINT_OS := $(shell uname)
 LINT_ARCH := $(shell uname -m)
 
-# shellcheck and hadolint don't have arm64 native binaries: use Rosetta instead
+# shellcheck and hadolint lack arm64 native binaries: rely on x86-64 emulation
 ifeq ($(LINT_OS),Darwin)
 	ifeq ($(LINT_ARCH),arm64)
 		LINT_ARCH=x86_64
@@ -31,18 +31,18 @@ endif
 LINT_LOWER_OS  = $(shell echo $(LINT_OS) | tr '[:upper:]' '[:lower:]')
 
 
-lint: out/linters/shellcheck-$(SHELLCHECK_VERSION)/shellcheck out/linters/hadolint-$(HADOLINT_VERSION) 
-	out/linters/hadolint-$(HADOLINT_VERSION) -t info $(shell find . -name "*Dockerfile")
-	out/linters/shellcheck-$(SHELLCHECK_VERSION)/shellcheck $(shell find . -name "*.sh")
+lint: out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH) 
+	out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH) -t info $(shell find . -name "*Dockerfile")
+	out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck $(shell find . -name "*.sh")
 
-out/linters/shellcheck-$(SHELLCHECK_VERSION)/shellcheck:
+out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck:
 	mkdir -p out/linters
-	curl -sfL https://github.com/koalaman/shellcheck/releases/download/v0.7.2/shellcheck-$(SHELLCHECK_VERSION).$(LINT_LOWER_OS).$(LINT_ARCH).tar.xz | tar -C out/linters -xJf -
+	curl -sSfL https://github.com/koalaman/shellcheck/releases/download/$(SHELLCHECK_VERSION)/shellcheck-$(SHELLCHECK_VERSION).$(LINT_LOWER_OS).$(LINT_ARCH).tar.xz | tar -C out/linters -xJf -
+	mv out/linters/shellcheck-$(SHELLCHECK_VERSION) out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)
 
-out/linters/hadolint-$(HADOLINT_VERSION):
+out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH):
 	mkdir -p out/linters
-	curl -sfL https://github.com/hadolint/hadolint/releases/download/v2.6.1/hadolint-$(LINT_OS)-$(LINT_ARCH) > out/linters/hadolint-$(HADOLINT_VERSION)
-	chmod u+x out/linters/hadolint-$(HADOLINT_VERSION)
+	curl -sfL https://github.com/hadolint/hadolint/releases/download/v2.6.1/hadolint-$(LINT_OS)-$(LINT_ARCH) > out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH)
+	chmod u+x out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH)
 
-
-# END: lint-install ../crocodile/
+# END: lint-install .

--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,38 @@ run: image
 .PHONY: image
 image:
 	docker build -t croc .
+
+# BEGIN: lint-install ../crocodile/
+# http://github.com/tinkerbell/lint-install
+
+
+HADOLINT_VERSION ?= v2.7.0
+SHELLCHECK_VERSION ?= v0.7.2
+LINT_OS := $(shell uname)
+LINT_ARCH := $(shell uname -m)
+
+# shellcheck and hadolint don't have arm64 native binaries: use Rosetta instead
+ifeq ($(LINT_OS),Darwin)
+	ifeq ($(LINT_ARCH),arm64)
+		LINT_ARCH=x86_64
+	endif
+endif
+
+LINT_LOWER_OS  = $(shell echo $(LINT_OS) | tr '[:upper:]' '[:lower:]')
+
+
+lint: out/linters/shellcheck-$(SHELLCHECK_VERSION)/shellcheck out/linters/hadolint-$(HADOLINT_VERSION) 
+	out/linters/hadolint-$(HADOLINT_VERSION) -t info $(shell find . -name "*Dockerfile")
+	out/linters/shellcheck-$(SHELLCHECK_VERSION)/shellcheck $(shell find . -name "*.sh")
+
+out/linters/shellcheck-$(SHELLCHECK_VERSION)/shellcheck:
+	mkdir -p out/linters
+	curl -sfL https://github.com/koalaman/shellcheck/releases/download/v0.7.2/shellcheck-$(SHELLCHECK_VERSION).$(LINT_LOWER_OS).$(LINT_ARCH).tar.xz | tar -C out/linters -xJf -
+
+out/linters/hadolint-$(HADOLINT_VERSION):
+	mkdir -p out/linters
+	curl -sfL https://github.com/hadolint/hadolint/releases/download/v2.6.1/hadolint-$(LINT_OS)-$(LINT_ARCH) > out/linters/hadolint-$(HADOLINT_VERSION)
+	chmod u+x out/linters/hadolint-$(HADOLINT_VERSION)
+
+
+# END: lint-install ../crocodile/

--- a/http/arch/ssh.sh
+++ b/http/arch/ssh.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
-PASSWORD=$(/usr/bin/openssl passwd -crypt 'tinkerbell')
+PASSWORD="$(/usr/bin/openssl passwd -crypt 'tinkerbell')"
 
 # Tinkerbell configuration
-/usr/bin/useradd --password ${PASSWORD} --comment 'Tinkerbell User' --create-home --user-group tinkerbell
+/usr/bin/useradd --password "${PASSWORD}" --comment 'Tinkerbell User' --create-home --user-group tinkerbell
 echo 'Defaults env_keep += "SSH_AUTH_SOCK"' > /etc/sudoers.d/10_tinkerbell
 echo 'tinkerbell ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers.d/10_tinkerbell
 /usr/bin/chmod 0440 /etc/sudoers.d/10_tinkerbell

--- a/scripts/arch/install-base.sh
+++ b/scripts/arch/install-base.sh
@@ -62,7 +62,7 @@ echo ">>>> install-base.sh: Generating the filesystem table.."
 echo ">>>> install-base.sh: Generating the system configuration script.."
 /usr/bin/install --mode=0755 /dev/null "${TARGET_DIR}${CONFIG_SCRIPT}"
 
-CONFIG_SCRIPT_SHORT=`basename "$CONFIG_SCRIPT"`
+CONFIG_SCRIPT_SHORT="$(basename "${CONFIG_SCRIPT}")"
 cat <<-EOF > "${TARGET_DIR}${CONFIG_SCRIPT}"
   echo ">>>> ${CONFIG_SCRIPT_SHORT}: Configuring hostname, timezone, and keymap.."
   echo '${FQDN}' > /etc/hostname
@@ -117,6 +117,6 @@ echo ">>>> install-base.sh: Completing installation.."
 # Turning network interfaces down to make sure SSH session was dropped on host.
 # More info at: https://www.packer.io/docs/provisioners/shell.html#handling-reboots
 echo '==> Turning down network interfaces and rebooting'
-for i in $(/usr/bin/netstat -i | /usr/bin/tail +3 | /usr/bin/awk '{print $1}'); do /usr/bin/ip link set ${i} down; done
+for i in $(/usr/bin/netstat -i | /usr/bin/tail +3 | /usr/bin/awk '{print $1}'); do /usr/bin/ip link set "${i}" down; done
 /usr/bin/systemctl reboot
 echo ">>>> install-base.sh: Installation complete!"

--- a/scripts/esxi/sysprep.sh
+++ b/scripts/esxi/sysprep.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -euxo pipefail
 
 # install the packer VIB (vSphere Installation Bundle) to automatically


### PR DESCRIPTION
Adds `make lint` rule to the Makefile using http://github.com/tinkerbell/lint-install and addresses some lint issues:

## Dockerfile

```
Dockerfile:1 DL3007 warning: Using latest is prone to errors if the image will ever update. Pin the version explicitly to a release tag
Dockerfile:2 DL3008 warning: Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`
Dockerfile:2 DL3015 info: Avoid additional packages by specifying `--no-install-recommends`
Dockerfile:2 DL3009 info: Delete the apt-get lists after installing something
Dockerfile:9 DL4006 warning: Set the SHELL option -o pipefail before RUN with a pipe in it. If you are using /bin/sh in an alpine image or if your shell is symlinked to busybox then consider explicitly setting your SHELL to /bin/ash, or disable this check
Dockerfile:9 SC2155 warning: Declare and assign separately to avoid masking return values.
```

## Shell

```

In ./http/arch/ssh.sh line 6:
/usr/bin/useradd --password ${PASSWORD} --comment 'Tinkerbell User' --create-home --user-group tinkerbell
                            ^---------^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean: 
/usr/bin/useradd --password "${PASSWORD}" --comment 'Tinkerbell User' --create-home --user-group tinkerbell


In ./scripts/esxi/sysprep.sh line 2:
set -euxo pipefail
          ^------^ SC3040: In POSIX sh, set option pipefail is undefined.


In ./scripts/arch/install-base.sh line 65:
CONFIG_SCRIPT_SHORT=`basename "$CONFIG_SCRIPT"`
                    ^-------------------------^ SC2006: Use $(...) notation instead of legacy backticked `...`.

Did you mean: 
CONFIG_SCRIPT_SHORT=$(basename "$CONFIG_SCRIPT")


In ./scripts/arch/install-base.sh line 120:
for i in $(/usr/bin/netstat -i | /usr/bin/tail +3 | /usr/bin/awk '{print $1}'); do /usr/bin/ip link set ${i} down; done
                                                                                                        ^--^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean: 
for i in $(/usr/bin/netstat -i | /usr/bin/tail +3 | /usr/bin/awk '{print $1}'); do /usr/bin/ip link set "${i}" down; done


In ./crocodile.sh line 12:
WIN20ISO="https://software-download.microsoft.com/download/pr/19041.264.200511-0456.vb_release_svc_refresh_CLIENTENTERPRISEEVAL_OEMRET_x64FRE_en-us.iso"
^------^ SC2034: WIN20ISO appears unused. Verify use (or export if used externally).


In ./crocodile.sh line 85:
      export ISO_URL=$WIN10ISO
                     ^-------^ SC2153: Possible misspelling: WIN10ISO may not be assigned, but WIN20ISO is.
```

The latter was also fixed by #31 - so I've merged that in and rebased.
