### PR TITLE
esxi/sysprep: invoke /bin/sh instead of /bin/bash

### DIFF
--- a/scripts/esxi/sysprep.sh
+++ b/scripts/esxi/sysprep.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -euxo pipefail
 
 # install the packer VIB (vSphere Installation Bundle) to automatically


### PR DESCRIPTION
There is no ~spoon~ bash on the esxi installer... this breaks everything

## Description

Reverts the `sh` -> `bash`

## Why is this needed

```
2021/11/10 16:27:42 packer-builder-qemu plugin: [ERROR] Remote command exited with '127': chmod +x /tmp/script_513.sh; PACKER_BUILDER_TYPE='qemu' PACKER_BUILD_NAME='qemu' PACKER_HTTP_ADDR='192.168.122.1:8613' PACKER_HTTP_IP='192.168.122.1' PACKER_HTTP_PORT='8613'  /tmp/script_513.sh
```
Is the reported error `127` is when a command can't be found.

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
