### PR TITLE
November 2021 bug fix and readme updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update \
    ansible=2.10.7-1 \
    git=1:2.30.2-1ubuntu1 \
    qemu-kvm \
+   qemu-utils \
    unzip=6.0-26ubuntu1 \
    xorriso=1.5.2-1 \
    curl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
    qemu-kvm \
    unzip=6.0-26ubuntu1 \
    xorriso=1.5.2-1 \
-   curl=7.74.0-1ubuntu2.1 \
+   curl \
    jq=1.6-2.1ubuntu1 \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Crocodile
 
 The **Crocodile** repository contains everything that a user should need in order to build Windows{x} compressed raw images
-for [tinkerbell](https://tinkerbell.org). 
+for [tinkerbell](https://tinkerbell.org).
 
 **Note:** These images are for the _Community_ and are not part of [Equinix Metal Operating System Images](https://metal.equinix.com/developers/docs/operating-systems/).
 
@@ -19,7 +19,7 @@ the Operating System images:
 ## Host requirements
 
 ### Minimal
-For most OS image builds, all you should really need is Docker on a reasonably modern Linux distro with KVM virtualization support.
+For most OS image builds, all you should really need is Docker on a reasonably modern Linux distro with KVM virtualization support. *Ubuntu docker hosts may need to reboot after ensuring that `libvirt-daemon-system` is installed prior to running crocodile. 
 
 ### ESXi special requirements
 To build ESXi images we depend on special bridged networking provided by libvirt-daemon.
@@ -45,6 +45,9 @@ We will map two directories into our running container:
 
 `-v $PWD/images:/var/tmp/images` - Maps a local `images` folder to where the images will be created.
 
+Ubuntu docker hosts may also require the following additional options:
+
+`--privileged -it --rm -v $PWD/packer_cache:/packer/packer_cache -v $PWD/images:/var/tmp/images -v /dev/net:/dev/net`
 ### Interactive
 
 Without passing anything specific to the container it will default to starting the interactive image building process.

--- a/scripts/esxi/sysprep.sh
+++ b/scripts/esxi/sysprep.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -euxo pipefail
 
 # install the packer VIB (vSphere Installation Bundle) to automatically


### PR DESCRIPTION
## Description

This PR contains some bug fixes around ESXi sysprep and supporting croc on Ubuntu 20 docker hosts. This PR also contains some updates to the README examples and requirements. 

## Why is this needed

This is necessary to better support VMware ESXi builds.

Fixes: #

## How Has This Been Tested?
Tested via manual image builds of ESXi on both a Ubuntu 20.04 and 20.10 docker host build environment.


## How are existing users impacted? What migration steps/scripts do we need?
No existing user impact expected.


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
