### PR TITLE
Bump curl pin in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
    qemu-kvm \
    unzip=6.0-26ubuntu1 \
    xorriso=1.5.2-1 \
-   curl=7.74.0-1ubuntu2.1 \
+   curl=7.74.0-1ubuntu2.3 \
    jq=1.6-2.1ubuntu1 \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Description

Bumps version of curl pinned in Dockerfile.

## Why is this needed

The previously pinned version seems to have been pulled from the mirrors, this version seems to be its replacement.

Fixes: #36 

## How Has This Been Tested?

I ran `docker build .` and made it past the faulty install phase.