### PR TITLE
adding remote sha1sum over https to ensure current sha1sum

### DIFF
--- a/configs/ubuntu-cloud-init.json
+++ b/configs/ubuntu-cloud-init.json
@@ -76,7 +76,7 @@
     "disk_size": "{{ env `DISK_SIZE` }}",
     "headless": "true",
     "memory": "4096",
-    "iso_checksum": "linux_iso.sha256",
+    "iso_checksum": "https://cloud-images.ubuntu.com/releases/focal/release/SHA1SUMS",
     "iso_url": "{{ env `ISO_URL` }}",
     "name": "{{ env `NAME` }}",
     "ubuntu_version": "{{ env `VERSION` }}",


### PR DESCRIPTION
## Description

Ubuntu's sha1 checksum is defined in a static file. Since the ubuntu image you are using is a LTS it's hash will, at minimum, change based on it's new point releases (i.e. 20.04.1 :arrow_right: 20.04.2 ), so the file's hash will have to manually be updated. This PR references the https file that Ubuntu (Canonical) provides to all the sha1sums that they put out for the imgs, this will allow the hash to be retrieved securely (over https) and dynamically based on new releases.

## Why is this needed

When trying to build the ubuntu-2004-cloud-init img, it failed because of the checksum not be correct.

![image](https://user-images.githubusercontent.com/10230166/157154993-73b411da-ef29-4fa6-96f7-05faadbff0cc.png)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

used this instead of the normal command (only difference being that I mapped in the configs to pickup my change), and everything built properly.

```console
$ docker run -it --rm \                                                                                                                                               
-v $PWD/packer_cache:/packer/packer_cache \                                                                                                                              
-v $PWD/images:/var/tmp/images \                                                                                                                                         
-v $PWD/configs:/packer/configs \                                                    
--net=host \                                                                                                                                                             
--device=/dev/kvm \                                                                                                                                                      
croc:latest

```

Ubuntu 21.10 (host OS)
Container info:
- Ubuntu 20.04
- packer: v1.8.0
- QEMU emulator version 5.2.0 (Debian 1:5.2+dfsg-9ubuntu3.3)

## How are existing users impacted? What migration steps/scripts do we need?

unblocks installation, and just have to pull the most recent changes from the repo.

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
