### PR TITLE
Update Window 10 Autounattend.xml to fix the winrm_username/password mismatch

### DIFF
--- a/http/windows-10/Autounattend.xml
+++ b/http/windows-10/Autounattend.xml
@@ -29,8 +29,8 @@
             </DiskConfiguration>
             <UserData>
                 <AcceptEula>true</AcceptEula>
-                <FullName>Vagrant</FullName>
-                <Organization>Vagrant</Organization>
+                <FullName>tinkerbell</FullName>
+                <Organization>Equinix Metal</Organization>
 
                 <!--
                     NOTE: If you are re-configuring this for use of a retail key
@@ -103,19 +103,19 @@
         <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" language="neutral" name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" versionScope="nonSxS">
             <UserAccounts>
                 <AdministratorPassword>
-                    <Value>vagrant</Value>
+                    <Value>tinkerbell</Value>
                     <PlainText>true</PlainText>
                 </AdministratorPassword>
                 <LocalAccounts>
                     <LocalAccount wcm:action="add">
                         <Password>
-                            <Value>vagrant</Value>
+                            <Value>tinkerbell</Value>
                             <PlainText>true</PlainText>
                         </Password>
-                        <Description>Vagrant User</Description>
-                        <DisplayName>vagrant</DisplayName>
                         <Group>administrators</Group>
-                        <Name>vagrant</Name>
+                        <DisplayName>tinkerbell</DisplayName>
+                        <Name>tinkerbell</Name>
+                        <Description>tinkerbell User</Description>
                     </LocalAccount>
                 </LocalAccounts>
             </UserAccounts>
@@ -130,10 +130,10 @@
             </OOBE>
             <AutoLogon>
                 <Password>
-                    <Value>vagrant</Value>
+                    <Value>tinkerbell</Value>
                     <PlainText>true</PlainText>
                 </Password>
-                <Username>vagrant</Username>
+                <Username>tinkerbell</Username>
                 <Enabled>true</Enabled>
             </AutoLogon>
             <FirstLogonCommands>


### PR DESCRIPTION
Signed-off-by: Xiaodong Ye <yeahdongcn@gmail.com>

## Description

<!--- Please describe what this PR is going to change -->
For Windows 10, `winrm_username` and `winrm_password` are set to `tinkerbell`, but the `Autounattend.xml` set them to `vagrant`.

## Why is this needed
In provision of `Windows 10` image, `winrm` won't connect successfully.

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
